### PR TITLE
feat: support proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "axios": "^1.10.0",
         "debug": "^4.4.1",
+        "https-proxy-agent": "^9.0.0",
         "openurl": "^1.1.1",
+        "proxy-from-env": "^2.1.0",
         "ws": "^8.18.2",
         "yargs": "^18.0.0"
       },
@@ -29,6 +31,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.0.3",
         "@types/openurl": "^1.0.3",
+        "@types/proxy-from-env": "^1.0.4",
         "@types/ws": "^8.18.1",
         "@types/yargs": "^17.0.33",
         "chai": "^5.2.0",
@@ -911,6 +914,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@semantic-release/github/node_modules/indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
@@ -1439,6 +1456,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/proxy-from-env": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/proxy-from-env/-/proxy-from-env-1.0.4.tgz",
+      "integrity": "sha512-TPR9/bCZAr3V1eHN4G3LD3OLicdJjqX1QRXWuNcCYgE66f/K8jO2ZRtHxI2D9MbnuUP6+qiKSS8eUHp6TFHGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -1621,6 +1648,12 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3198,17 +3231,25 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/human-signals": {
@@ -6579,10 +6620,13 @@
       "license": "ISC"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
   "dependencies": {
     "axios": "^1.10.0",
     "debug": "^4.4.1",
+    "https-proxy-agent": "^9.0.0",
     "openurl": "^1.1.1",
+    "proxy-from-env": "^2.1.0",
     "ws": "^8.18.2",
     "yargs": "^18.0.0"
   },
@@ -75,6 +77,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.3",
     "@types/openurl": "^1.0.3",
+    "@types/proxy-from-env": "^1.0.4",
     "@types/ws": "^8.18.1",
     "@types/yargs": "^17.0.33",
     "chai": "^5.2.0",

--- a/src/bin/lr.ts
+++ b/src/bin/lr.ts
@@ -95,6 +95,15 @@ const args = yargs(hideBin(process.argv))
     describe: 'Print basic request info',
     type: 'boolean',
   })
+  .option('proxy', {
+    describe:
+      'Proxy server URL (e.g. https://proxy:8080). Auto-detects from HTTPS_PROXY/HTTP_PROXY env vars if not specified.',
+    type: 'string',
+  })
+  .option('no-proxy', {
+    describe: 'Disable proxy even if HTTPS_PROXY/HTTP_PROXY env vars are set',
+    type: 'boolean',
+  })
   .help('help', 'Show this help and exit')
   .version(version)
 
@@ -148,6 +157,12 @@ function formatRequestLog(info: { method: string; path: string; headers?: Record
   }
 
   try {
+    if (argv['no-proxy']) {
+      console.log('Proxy disabled')
+    } else if (argv.proxy) {
+      console.log(`Using proxy: ${argv.proxy}`)
+    }
+
     const tunnel = await localrun(argv.port as number, {
       host: argv.host as string,
       subdomain: argv.subdomain as string,
@@ -161,6 +176,8 @@ function formatRequestLog(info: { method: string; path: string; headers?: Record
       maxRetries: argv['max-retries'] as number,
       maxReconnectAttempts: argv['max-reconnect-attempts'] as number,
       sseTimeout: argv['sse-timeout'] as number,
+      proxy: argv.proxy as string | undefined,
+      noProxy: argv['no-proxy'] as boolean | undefined,
     })
 
     tunnel.on('url', (url: string) => {

--- a/src/bin/lr.ts
+++ b/src/bin/lr.ts
@@ -97,18 +97,24 @@ const args = yargs(hideBin(process.argv))
   })
   .option('proxy', {
     describe:
-      'Proxy server URL (e.g. https://proxy:8080). Auto-detects from HTTPS_PROXY/HTTP_PROXY env vars if not specified.',
+      'Proxy server URL (e.g. http://proxy:8080). Auto-detects from HTTPS_PROXY/HTTP_PROXY env vars if not specified. Use --no-proxy to disable.',
     type: 'string',
-  })
-  .option('no-proxy', {
-    describe: 'Disable proxy even if HTTPS_PROXY/HTTP_PROXY env vars are set',
-    type: 'boolean',
   })
   .help('help', 'Show this help and exit')
   .version(version)
 
 function formatTimestamp(): string {
   return new Date().toISOString().replace('T', ' ').substring(0, 19)
+}
+
+function redactProxyUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    if (parsed.password) parsed.password = '***'
+    return parsed.toString()
+  } catch {
+    return url
+  }
 }
 
 function formatRequestLog(info: { method: string; path: string; headers?: Record<string, string> }): string {
@@ -157,10 +163,14 @@ function formatRequestLog(info: { method: string; path: string; headers?: Record
   }
 
   try {
-    if (argv['no-proxy']) {
+    const rawProxy = argv.proxy as string | boolean | undefined
+    const proxyDisabled = rawProxy === false
+    const proxyUrl = typeof rawProxy === 'string' ? rawProxy : undefined
+
+    if (proxyDisabled) {
       console.log('Proxy disabled')
-    } else if (argv.proxy) {
-      console.log(`Using proxy: ${argv.proxy}`)
+    } else if (proxyUrl) {
+      console.log(`Using proxy: ${redactProxyUrl(proxyUrl)}`)
     }
 
     const tunnel = await localrun(argv.port as number, {
@@ -176,8 +186,8 @@ function formatRequestLog(info: { method: string; path: string; headers?: Record
       maxRetries: argv['max-retries'] as number,
       maxReconnectAttempts: argv['max-reconnect-attempts'] as number,
       sseTimeout: argv['sse-timeout'] as number,
-      proxy: argv.proxy as string | undefined,
-      noProxy: argv['no-proxy'] as boolean | undefined,
+      proxy: proxyUrl,
+      noProxy: proxyDisabled || undefined,
     })
 
     tunnel.on('url', (url: string) => {
@@ -206,7 +216,7 @@ function formatRequestLog(info: { method: string; path: string; headers?: Record
 
     tunnel.on('url', () => {
       const connectionTime = Date.now() - connectionStartTime
-      console.log(`⏱️ Connection established in ${connectionTime}ms`)
+      console.log(`⏱ Connection established in ${connectionTime}ms`)
     })
 
     tunnel.on('close', () => {

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -151,15 +151,23 @@ export class Tunnel extends EventEmitter {
   }
 
   private resolveProxy(): void {
-    this.proxyAgent?.destroy()
+    try {
+      this.proxyAgent?.destroy()
+    } catch (error) {
+      log('Error destroying previous proxy agent:', error)
+    }
     this.proxyAgent = null
 
+    const explicit = this.options.proxy?.trim() || undefined
+
     if (this.options.noProxy) {
+      if (explicit) {
+        log('Warning: both proxy and noProxy are set; noProxy takes precedence')
+      }
       log('Proxy explicitly disabled')
       return
     }
 
-    const explicit = this.options.proxy
     const proxyUrl = explicit ?? getProxyForUrl(this.options.host ?? '')
     if (!proxyUrl) {
       log('No proxy configured')
@@ -170,12 +178,18 @@ export class Tunnel extends EventEmitter {
       if (explicit) {
         throw new Error(`Invalid proxy URL: ${proxyUrl}`)
       }
+      console.error(`Warning: Invalid proxy URL from environment variable, ignoring: ${proxyUrl}`)
       log('Invalid proxy URL from environment, skipping: %s', proxyUrl)
       return
     }
 
     log('Using proxy: %s', proxyUrl)
-    this.proxyAgent = new HttpsProxyAgent(proxyUrl)
+    try {
+      this.proxyAgent = new HttpsProxyAgent(proxyUrl)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Failed to create proxy agent for ${proxyUrl}: ${message}`)
+    }
   }
 
   private async initTunnel(): Promise<TunnelInfo> {
@@ -187,7 +201,8 @@ export class Tunnel extends EventEmitter {
       const axiosConfig: AxiosRequestConfig = {
         responseType: 'json',
         timeout: 10000,
-        ...(this.proxyAgent && { httpsAgent: this.proxyAgent, proxy: false as const }),
+        // proxyAgent がある場合は、そちらを優先して使う
+        ...(this.proxyAgent && { httpsAgent: this.proxyAgent, proxy: false }),
       }
 
       let response: AxiosResponse<{
@@ -228,7 +243,8 @@ export class Tunnel extends EventEmitter {
     } catch (error) {
       log('tunnel server error:', error)
       if (axios.isAxiosError(error)) {
-        throw new Error(`Failed to connect to tunnel server: ${error.message}`)
+        const proxyInfo = this.proxyAgent ? ' (via proxy)' : ''
+        throw new Error(`Failed to connect to tunnel server${proxyInfo}: ${error.message}`)
       }
       throw error
     }
@@ -1154,7 +1170,11 @@ export class Tunnel extends EventEmitter {
     }
 
     if (this.proxyAgent) {
-      this.proxyAgent.destroy()
+      try {
+        this.proxyAgent.destroy()
+      } catch (error) {
+        log('Error destroying proxy agent:', error)
+      }
       this.proxyAgent = null
     }
 

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -4,8 +4,10 @@ import * as http from 'node:http'
 import * as https from 'node:https'
 import * as net from 'node:net'
 import * as zlib from 'node:zlib'
-import axios, { type AxiosResponse } from 'axios'
+import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios'
 import debug from 'debug'
+import { HttpsProxyAgent } from 'https-proxy-agent'
+import { getProxyForUrl } from 'proxy-from-env'
 import WebSocket from 'ws'
 import { messageChunker } from './chunk-utils.js'
 import { LocalPortConnectionError, type LocalPortErrorCode, type LocalPortValidationResult } from './error.js'
@@ -59,6 +61,7 @@ export class Tunnel extends EventEmitter {
   private maxReconnectAttempts = 10
   private reconnectAttempts = 0
   private keepAliveInterval: ReturnType<typeof setInterval> | null = null // 追加
+  private proxyAgent: http.Agent | null = null
   private reconnectBackoffMultiplier = 1.5 // 追加：指数バックオフ
   private maxReconnectDelay = 30000 // 追加：最大再接続遅延（30秒）
 
@@ -114,6 +117,8 @@ export class Tunnel extends EventEmitter {
     }
     log('✅ Local port validation successful')
 
+    this.resolveProxy()
+
     return new Promise((resolve, reject) => {
       this.initTunnel()
         .then((info) => {
@@ -145,12 +150,46 @@ export class Tunnel extends EventEmitter {
     })
   }
 
+  private resolveProxy(): void {
+    this.proxyAgent?.destroy()
+    this.proxyAgent = null
+
+    if (this.options.noProxy) {
+      log('Proxy explicitly disabled')
+      return
+    }
+
+    const explicit = this.options.proxy
+    const proxyUrl = explicit ?? getProxyForUrl(this.options.host ?? '')
+    if (!proxyUrl) {
+      log('No proxy configured')
+      return
+    }
+
+    if (!URL.canParse(proxyUrl)) {
+      if (explicit) {
+        throw new Error(`Invalid proxy URL: ${proxyUrl}`)
+      }
+      log('Invalid proxy URL from environment, skipping: %s', proxyUrl)
+      return
+    }
+
+    log('Using proxy: %s', proxyUrl)
+    this.proxyAgent = new HttpsProxyAgent(proxyUrl)
+  }
+
   private async initTunnel(): Promise<TunnelInfo> {
     const endpoint = this.options.subdomain ? `${this.options.host}/api/tunnels` : `${this.options.host}/?new`
 
     log('requesting tunnel from %s', endpoint)
 
     try {
+      const axiosConfig: AxiosRequestConfig = {
+        responseType: 'json',
+        timeout: 10000,
+        ...(this.proxyAgent && { httpsAgent: this.proxyAgent, proxy: false as const }),
+      }
+
       let response: AxiosResponse<{
         id: string
         url: string
@@ -166,17 +205,11 @@ export class Tunnel extends EventEmitter {
           {
             subdomain: this.options.subdomain,
           },
-          {
-            responseType: 'json',
-            timeout: 10000,
-          },
+          axiosConfig,
         )
       } else {
         // GET request for random subdomain
-        response = await axios.get(endpoint, {
-          responseType: 'json',
-          timeout: 10000,
-        })
+        response = await axios.get(endpoint, axiosConfig)
       }
 
       if (response.status !== 200) {
@@ -218,9 +251,12 @@ export class Tunnel extends EventEmitter {
       this.keepAliveInterval = null
     }
 
-    this.websocket = new WebSocket(wsUrl, {
+    const wsOptions: WebSocket.ClientOptions = {
       handshakeTimeout: 10000,
-    })
+      ...(this.proxyAgent && { agent: this.proxyAgent }),
+    }
+
+    this.websocket = new WebSocket(wsUrl, wsOptions)
 
     this.websocket.on('open', () => {
       log('✅ WebSocket connected successfully')
@@ -1115,6 +1151,11 @@ export class Tunnel extends EventEmitter {
     if (this.localServer) {
       this.localServer.close()
       this.localServer = null
+    }
+
+    if (this.proxyAgent) {
+      this.proxyAgent.destroy()
+      this.proxyAgent = null
     }
 
     // メッセージチャンカーのクリーンアップ

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,10 @@ export interface TunnelOptions {
   maxRetries?: number
   maxReconnectAttempts?: number
   sseTimeout?: number
+  /** Explicit proxy URL. When omitted, proxy is auto-detected from HTTPS_PROXY / HTTP_PROXY / NO_PROXY env vars. */
+  proxy?: string
+  /** Disable proxy entirely, even when env vars are set. Takes precedence over `proxy`. */
+  noProxy?: boolean
 }
 
 export interface TunnelInfo {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -224,6 +224,79 @@ describe('CLI (lr.ts)', () => {
     }).timeout(5000)
   })
 
+  describe('proxy options', () => {
+    it('should show --proxy option in help', async () => {
+      const process = spawnCli(['--help'])
+      const output = collectOutput(process)
+      const { code } = await waitForClose(process)
+      expect(code).to.equal(0)
+      expect(output.getStdout()).to.include('--proxy')
+    }).timeout(5000)
+
+    it('should print proxy URL when --proxy is specified', async () => {
+      const childProcess = spawnCli([
+        '--port', '99999',
+        '--proxy', 'http://127.0.0.1:9999',
+        '--timeout', '1000',
+      ])
+      const output = collectOutput(childProcess)
+      await waitForStdoutContains(childProcess, 'Using proxy')
+      await terminateAndWait(childProcess)
+      expect(output.getStdout()).to.include('Using proxy')
+    }).timeout(5000)
+
+    it('should print "Proxy disabled" when --no-proxy is specified', async () => {
+      const childProcess = spawnCli([
+        '--port', '99999',
+        '--no-proxy',
+        '--timeout', '1000',
+      ])
+      const output = collectOutput(childProcess)
+      await waitForStdoutContains(childProcess, 'Proxy disabled')
+      await terminateAndWait(childProcess)
+      expect(output.getStdout()).to.include('Proxy disabled')
+    }).timeout(5000)
+
+    it('should fail with invalid --proxy URL', async () => {
+      // Need a running server so port validation passes before proxy validation
+      const server = http.createServer((_req, res) => {
+        res.writeHead(200)
+        res.end('ok')
+      })
+      await new Promise<void>((resolve) => server.listen(0, resolve))
+      const address = server.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+
+      const childProcess = spawnCli([
+        '--port', String(port),
+        '--proxy', 'not-a-url',
+        '--timeout', '1000',
+      ])
+      const output = collectOutput(childProcess)
+      const { code } = await waitForClose(childProcess)
+
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+
+      expect(code).to.not.equal(0)
+      expect(output.getStderr()).to.include('Invalid proxy URL')
+    }).timeout(5000)
+
+    it('should redact credentials in proxy URL output', async () => {
+      const childProcess = spawnCli([
+        '--port', '99999',
+        '--proxy', 'http://user:secret@proxy.example.com:8080',
+        '--timeout', '1000',
+      ])
+      const output = collectOutput(childProcess)
+      await waitForStdoutContains(childProcess, 'Using proxy')
+      await terminateAndWait(childProcess)
+      expect(output.getStdout()).to.include('Using proxy')
+      expect(output.getStdout()).to.not.include('secret')
+    }).timeout(5000)
+  })
+
   describe('argument parsing edge cases', () => {
     it('should handle numeric arguments correctly', async () => {
       const process = spawnCli([

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -36,6 +36,8 @@ describe('Types', () => {
         allowInvalidCert: true,
         timeout: 30000,
         maxRetries: 5,
+        proxy: 'http://proxy:8080',
+        noProxy: false,
       }
 
       expect(options.port).to.equal(3000)
@@ -49,6 +51,8 @@ describe('Types', () => {
       expect(options.allowInvalidCert).to.be.true
       expect(options.timeout).to.equal(30000)
       expect(options.maxRetries).to.equal(5)
+      expect(options.proxy).to.equal('http://proxy:8080')
+      expect(options.noProxy).to.be.false
     })
   })
 


### PR DESCRIPTION
## Summary

`lr` から HTTP(S) Proxy 経由でトンネルサーバへ接続できるようにした。企業ネットワーク配下など、外部への直接接続が制限される環境でも利用可能にする。

- CLI に `--proxy` / `--no-proxy` を追加
- 未指定時は `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` 環境変数から自動検出 (`proxy-from-env`)
- API リクエスト (axios) と WebSocket (`ws`) の両方に proxy を適用

## 通信経路

### Before (proxy なし / 従来)

```mermaid
flowchart LR
    CLI[localrun CLI] -->|HTTPS API| S[Tunnel Server]
    CLI -->|WSS| S
```

### After (proxy あり)

```mermaid
flowchart LR
    CLI[localrun CLI] -->|CONNECT| P[HTTP/HTTPS Proxy]
    P -->|HTTPS API| S[Tunnel Server]
    P -->|WSS tunneled| S
```

## Proxy 解決ロジック

優先順位は `--no-proxy` > `--proxy` > 環境変数 (`HTTPS_PROXY` / `HTTP_PROXY`、`NO_PROXY` でバイパス)。

> **Note**: `--no-proxy` は yargs 組み込みの `--no-` プレフィックスネゲーションを利用している（`argv.proxy === false` で検出）。

```mermaid
flowchart TD
    A[Tunnel.open] --> B{noProxy?}
    B -- Yes --> Z[proxy 不使用]
    B -- No --> C{--proxy 指定?}
    C -- Yes --> D[明示 URL を採用]
    C -- No --> E["getProxyForUrl(host)"]
    E --> F{env から取得?}
    F -- No --> Z
    F -- Yes --> G[env URL を採用]
    D --> D2["trim() / 空文字正規化"]
    D2 --> H{URL.canParse?}
    G --> H
    H -- Yes --> I["try: HttpsProxyAgent 生成"]
    H -- No / 明示 --> X[Error throw]
    H -- No / env --> W["console.error 警告"] --> Z
    I --> J[axios httpsAgent と ws agent に注入]
```

## ライフサイクル

```mermaid
sequenceDiagram
    participant U as User
    participant T as Tunnel
    participant PA as HttpsProxyAgent
    participant P as Proxy
    participant S as Server

    U->>T: open()
    T->>T: resolveProxy()
    T->>PA: new HttpsProxyAgent(url)
    T->>PA: axios.get/post (httpsAgent)
    PA->>P: CONNECT
    P->>S: TLS
    S-->>T: tunnel info
    T->>PA: new WebSocket(url, { agent })
    PA->>P: CONNECT (wss)
    P->>S: WS handshake
    S-->>T: open
    Note over T,S: 以後 WS でコントロール
    U->>T: close()
    T->>PA: destroy()
```

## 主な変更

| File | Change |
|---|---|
| `src/bin/lr.ts` | `--proxy` / `--no-proxy` CLI オプションを追加。起動時に状態を表示。クレデンシャル付き URL のマスク対応 |
| `src/tunnel.ts` | `resolveProxy()` 追加。`initTunnel` / WS 接続で `httpsAgent`・`agent` を注入。`close()` で `destroy()`。エラーハンドリング強化 |
| `src/types.ts` | `TunnelOptions.proxy` / `noProxy` を追加 |
| `package.json` | `https-proxy-agent@^9`, `proxy-from-env@^2` (+ `@types/proxy-from-env`) |